### PR TITLE
Fix pipeline syntax generator adding empty fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 target
+work/

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.1</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,13 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>neuvector-vulnerability-scanner</artifactId>
-    <version>1.7-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
+        <revision>1.7</revision>
+        <changelist>-SNAPSHOT</changelist>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.150.4</jenkins.version>
+        <jenkins.version>2.150.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>NeuVector Vulnerability Scanner Plugin</name>
@@ -81,7 +83,6 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>neuvector-vulnerability-scanner-1.0</tag>
     </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.29</version>
+        <version>3.51</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -13,16 +13,8 @@
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>1.625.3</jenkins.version>
-        <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-        <java.level>7</java.level>
-        <!-- Jenkins Test Harness version you use to test the plugin. -->
-        <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-        <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
-        <!-- Other properties you may want to use:
-          ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-          ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-     -->
+        <jenkins.version>2.150.4</jenkins.version>
+        <java.level>8</java.level>
     </properties>
     <name>NeuVector Vulnerability Scanner Plugin</name>
     <description>Adds NeuVector registry and image scanning as a build step</description>
@@ -32,58 +24,49 @@
             <url>https://opensource.org/licenses/Apache-2.0</url>
         </license>
     </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.150.x</artifactId>
+                <version>3</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>2.12</version>
-            <scope>test</scope>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
         </dependency>
+
+        <!-- Test deps -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.39</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.13</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <version>2.20</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5</version>
         </dependency>
     </dependencies>
     <developers>
@@ -93,7 +76,7 @@
             <email>info@neuvector.com</email>
         </developer>
     </developers>
-    <url>https://wiki.jenkins.io/display/JENKINS/NeuVector+Vulnerability+Scanner+Plugin</url>
+    <url>https://github.com/jenkinsci/neuvector-vulnerability-scanner-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>

--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
@@ -32,6 +32,7 @@ import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
 
+import static hudson.Util.fixEmpty;
 
 public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
 
@@ -105,7 +106,7 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setTag(String tag) {
-        this.tag = tag.trim();
+        this.tag = fixEmpty(tag.trim());
     }
 
     @DataBoundSetter
@@ -115,32 +116,32 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setNumberOfHighSeverityToFail(String numberOfHighSeverityToFail) {
-        this.numberOfHighSeverityToFail = numberOfHighSeverityToFail.trim();
+        this.numberOfHighSeverityToFail = fixEmpty(numberOfHighSeverityToFail.trim());
     }
 
     @DataBoundSetter
     public void setNumberOfMediumSeverityToFail(String numberOfMediumSeverityToFail) {
-        this.numberOfMediumSeverityToFail = numberOfMediumSeverityToFail.trim();
+        this.numberOfMediumSeverityToFail = fixEmpty(numberOfMediumSeverityToFail.trim());
     }
 
     @DataBoundSetter
     public void setNameOfVulnerabilityToFailOne(String nameOfVulnerabilityToFailOne) {
-        this.nameOfVulnerabilityToFailOne = nameOfVulnerabilityToFailOne.trim();
+        this.nameOfVulnerabilityToFailOne = fixEmpty(nameOfVulnerabilityToFailOne.trim());
     }
 
     @DataBoundSetter
     public void setNameOfVulnerabilityToFailTwo(String nameOfVulnerabilityToFailTwo) {
-        this.nameOfVulnerabilityToFailTwo = nameOfVulnerabilityToFailTwo.trim();
+        this.nameOfVulnerabilityToFailTwo = fixEmpty(nameOfVulnerabilityToFailTwo.trim());
     }
 
     @DataBoundSetter
     public void setNameOfVulnerabilityToFailThree(String nameOfVulnerabilityToFailThree) {
-        this.nameOfVulnerabilityToFailThree = nameOfVulnerabilityToFailThree.trim();
+        this.nameOfVulnerabilityToFailThree = fixEmpty(nameOfVulnerabilityToFailThree.trim());
     }
 
     @DataBoundSetter
     public void setNameOfVulnerabilityToFailFour(String nameOfVulnerabilityToFailFour) {
-        this.nameOfVulnerabilityToFailFour = nameOfVulnerabilityToFailFour.trim();
+        this.nameOfVulnerabilityToFailFour = fixEmpty(nameOfVulnerabilityToFailFour.trim());
     }
 
     @Override
@@ -248,7 +249,7 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
     }
 
     private void archiveAndAddAction(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener, String artifactName, String reportNumber)
-            throws InterruptedException {
+            throws InterruptedException, IOException {
         ArtifactArchiver artifactArchiver = new ArtifactArchiver(artifactName);
         artifactArchiver.perform(run, workspace, launcher, listener);
         run.addAction(new NeuVectorAction(run, artifactName, reportNumber));

--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
@@ -12,6 +12,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Set;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.http.client.ClientProtocolException;
@@ -34,6 +36,7 @@ public class NeuVectorWorker {
 
     private static final int HTTP_CLIENT_CONFIG_TIMEOUT_SECOND = 60;
     private Log logger;
+    private static final Logger LOGGER = Logger.getLogger(NeuVectorWorker.class.getName());
     private Config config;
     private String token;
 
@@ -199,10 +202,10 @@ public class NeuVectorWorker {
                 throw new AbortException("Scan failed.");
             }
         } catch (AbortException e) {
-            throw new AbortException();
+            throw e;
         } catch (IOException e) {
-            logger.log("NeuVector controller connection error.");
-            throw new AbortException();
+            LOGGER.log(Level.WARNING, "NeuVector controller connection error", e);
+            throw new AbortException("NeuVector controller connection error. " + e.getMessage());
         } finally {
             if (httpResponseFromScan != null) {
                 httpResponseFromScan.close();
@@ -316,11 +319,11 @@ public class NeuVectorWorker {
                     logger.log();
                     for (int j = 0; j < layerVulnerabilityArray.size(); j++) {
                         JSONObject layerVulnerabilityObject = layerVulnerabilityArray.getJSONObject(j);
-                        logger.log("Name: " + layerVulnerabilityObject.getString("name") 
-                            + ", Score: " + layerVulnerabilityObject.get("score") 
-                            + ", Package_name: " + layerVulnerabilityObject.getString("package_name") 
-                            + ", Package_version: " + layerVulnerabilityObject.getString("package_version") 
-                            + ", Fixed_version: " + layerVulnerabilityObject.getString("fixed_version") 
+                        logger.log("Name: " + layerVulnerabilityObject.getString("name")
+                            + ", Score: " + layerVulnerabilityObject.get("score")
+                            + ", Package_name: " + layerVulnerabilityObject.getString("package_name")
+                            + ", Package_version: " + layerVulnerabilityObject.getString("package_version")
+                            + ", Fixed_version: " + layerVulnerabilityObject.getString("fixed_version")
                             + ", Link: " + layerVulnerabilityObject.getString("link"));
                     }
                     logger.log();

--- a/src/main/java/io/jenkins/plugins/neuvector/Registry.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/Registry.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.neuvector;
 
 import com.google.common.base.Strings;
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import java.io.Serializable;
@@ -9,6 +10,7 @@ import java.io.Serializable;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 public class Registry extends AbstractDescribableImpl<Registry> implements Serializable {
@@ -19,11 +21,30 @@ public class Registry extends AbstractDescribableImpl<Registry> implements Seria
     private String regUsername;
     private Secret regPassword;
 
-    @DataBoundConstructor
     public Registry(String nickname, String regUrl, String regUsername, Secret regPassword) {
         this.nickname = nickname.trim();
         this.regUrl = regUrl.trim();
         this.regUsername = regUsername.trim();
+        this.regPassword = regPassword;
+    }
+
+    @DataBoundConstructor
+    public Registry(String nickname, String regUrl) {
+        this.nickname = nickname;
+        this.regUrl = regUrl;
+    }
+
+    @DataBoundSetter
+    public void setRegUsername(String regUsername) {
+        this.regUsername = Util.fixEmpty(regUsername);
+    }
+
+    @DataBoundSetter
+    public void setRegPassword(Secret regPassword) {
+        if (regPassword.getPlainText().isEmpty()) {
+            this.regPassword = null;
+            return;
+        }
         this.regPassword = regPassword;
     }
 


### PR DESCRIPTION
Before:
```
neuvector nameOfVulnerabilityToFailFour: '', nameOfVulnerabilityToFailOne: '', nameOfVulnerabilityToFailThree: '', nameOfVulnerabilityToFailTwo: '', numberOfHighSeverityToFail: '1', numberOfMediumSeverityToFail: '1', registrySelection: 'dockerhub', repository: 'alpine', scanLayers: true, tag: 'latest'
```

After:
```
neuvector numberOfHighSeverityToFail: '1', numberOfMediumSeverityToFail: '1', registrySelection: 'dockerhub', repository: 'alpine', scanLayers: true, tag: 'latest'
```

Added BOM to simplify dependency management:
https://github.com/jenkinsci/bom

Used apache http client api plugin instead of direct dependency:
https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin

Bumped jenkins baseline to somewhat recent LTS, based off of:
http://stats.jenkins.io/pluginversions/neuvector-vulnerability-scanner.html

Used `DataBoundSetters` and `DataBoundConstructor` correctly in regards to optional and mandatory fields
https://jenkins.io/doc/developer/plugin-development/pipeline-integration/#constructor-vs-setters

I tried to add a test with [SnippetizerTester](https://github.com/jenkinsci/workflow-cps-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/cps/SnippetizerTester.java) but it doesn't seem to work with `BuildStep`'s

Incrementalize plugin:
https://github.com/jenkinsci/incrementals-tools

Any questions let me know, I can also provide more documentation 