### PR TITLE
fix Security-2865 / CVE-2022-43434

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ This is a Jenkins Plugin to do security vulnerabilities scan on registries and l
 
 See [GitHub releases](https://github.com/jenkinsci/neuvector-vulnerability-scanner-plugin/releases)
 
+1.21 (Oct 25, 2022)
+-----
+* Fix Security-2865 / CVE-2022-43434
+
 1.20 (May 26, 2022)
 -----
 * Remove the license from the NeuVector Scanner configuration.

--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
@@ -207,7 +207,7 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
         this.logger = new Log(listener.getLogger());
 
         // config the Jenkins CSP to allow the main panel to show html file
-        System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "default-src 'self'; style-src 'self' 'unsafe-inline';");
+        System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "default-src 'none'; style-src 'self'; img-src 'self';");
 
         // copy styles.css to workspace
         File cssFile;


### PR DESCRIPTION
removed the value 'unsafe-inline' from the property "style-src" in the Content-Security-Policy setting

- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or Jira
- [ x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
