### PR TITLE
fix Security-2865 / CVE-2022-43434

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ This is a Jenkins Plugin to do security vulnerabilities scan on registries and l
 
 See [GitHub releases](https://github.com/jenkinsci/neuvector-vulnerability-scanner-plugin/releases)
 
+1.22 (Oct 28, 2022)
+-----
+* Fix Security-2865 / CVE-2022-43434 
+
 1.21 (Oct 25, 2022)
 -----
 * Fix Security-2865 / CVE-2022-43434

--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
@@ -206,9 +206,6 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
         // init the logger
         this.logger = new Log(listener.getLogger());
 
-        // config the Jenkins CSP to allow the main panel to show html file
-        System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "default-src 'none'; style-src 'self'; img-src 'self';");
-
         // copy styles.css to workspace
         File cssFile;
         final EnvVars env = run.getEnvironment(listener);


### PR DESCRIPTION
removed the call to config the CSP header

- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
