### PR TITLE
Fix jenkins plugin running in k8s mode issue.

### DIFF
--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
@@ -341,7 +341,6 @@ public class NeuVectorWorker {
 
     private String scanByStandaloneScanner(Run<?, ?> run, Launcher launcher) throws IOException, InterruptedException{
         int exitCode = 0;
-        String buildPath;
         String scanResultPath;
         ArgumentListBuilder args = new ArgumentListBuilder();
 
@@ -393,15 +392,7 @@ public class NeuVectorWorker {
                You need to define an environment variable $JENKINS_MOUNT_PATH to store the host path.
                The scan result file can be found in $JENKINS_MOUNT_PATH/jobs/$JOB_NAME/build/$BUILD_NUMBER/scan_result.json
             */
-            final EnvVars env = run.getEnvironment(launcher.getListener());
-            buildPath = run.getRootDir().getAbsolutePath();
-
-
-            if(Objects.nonNull(env.get("JENKINS_MOUNT_PATH")) && !env.get("JENKINS_MOUNT_PATH").isEmpty()){
-                scanResultPath = buildPath.replace(env.get("JENKINS_HOME"), env.get("JENKINS_MOUNT_PATH"));
-            }else{
-                scanResultPath = buildPath;
-            }
+            scanResultPath = this.workspace.getRemote();
 
             String regUrl = "";
             if(!config.isLocal()){
@@ -475,11 +466,9 @@ public class NeuVectorWorker {
                 isScanFileExist = true;
             }
             else{
-                scanReport = buildPath + "/" + SCAN_REPORT;
+                scanReport = scanResultPath + "/" + SCAN_REPORT;
                 scanReportFile = new FilePath(launcher.getChannel(), scanReport);
-            }
-            if (scanReportFile.exists()){
-                isScanFileExist = true;
+                isScanFileExist = scanReportFile.exists();
             }
 
             TimeUnit.SECONDS.sleep(10);

--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.neuvector;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
-import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
@@ -365,7 +364,7 @@ public class NeuVectorWorker {
             if(exitCode != 0) {
                 logger.println("docker failed to login " + config.getScannerRegistryURL() + " Please check the global configuration.");
             }
-
+            
             // docker pull NeuVector Scanner
             args.clear();
             args.add("docker", "pull");
@@ -386,11 +385,7 @@ public class NeuVectorWorker {
 
             /*
                When the Jenkins runs as an application, the scan result file is generated
-               in $JENKINS_HOME/jobs/$JOB_NAME/build/$BUILD_NUMBER/scan_result.json.
-
-               When the Jenkins runs as a Docker container, $JENKINS_HOME inside the container gets mounted to a host path.
-               You need to define an environment variable $JENKINS_MOUNT_PATH to store the host path.
-               The scan result file can be found in $JENKINS_MOUNT_PATH/jobs/$JOB_NAME/build/$BUILD_NUMBER/scan_result.json
+               in {Jenkins worksapce}/scan_result.json.
             */
             scanResultPath = this.workspace.getRemote();
 
@@ -464,11 +459,6 @@ public class NeuVectorWorker {
         while ( !isScanFileExist && (timer < scanTimeout)){
             if (scanReportFile.exists()) {
                 isScanFileExist = true;
-            }
-            else{
-                scanReport = scanResultPath + "/" + SCAN_REPORT;
-                scanReportFile = new FilePath(launcher.getChannel(), scanReport);
-                isScanFileExist = scanReportFile.exists();
             }
 
             TimeUnit.SECONDS.sleep(10);


### PR DESCRIPTION
### Summary
1. Let neuvector plugin to run on both k8s mode and VM mode.
2. move the scan_report to workspace.

### Ticket
[NVSHAS-8056](https://jira.suse.com/browse/NVSHAS-8056)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
