### PR TITLE
Add isFromNonTLSVerificationVersion flag

### DIFF
--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
@@ -588,6 +588,14 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
             load();
         }
 
+        private boolean isFromNonTLSVerificationVersion() {
+            /*
+             * ServerCertificate must be null if the plugin is new installed or migrated from non-TLS verification version,
+             * since we add serverCertificate when we have TLS verification.
+             */
+            return (serverCertificate == null);
+        }
+
         public ListBoxModel doFillRegistrySelectionItems() {
             ListBoxModel items = new ListBoxModel();
             items.add(REGISTRY_DROPDOWN_DEFAULT);
@@ -705,13 +713,14 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
             /*
             * TLS certificate verification is enabled by default, but it will be disabled in the following scenario:
             * 
-            * To ensure compatibility with users who are upgrading from older versions, 
-            * we check if the user has previously used API mode when upgrading from older versions. 
+            * To ensure compatibility with users who are upgrading from non-TLS verification version, 
+            * we check if the user has previously used API mode when upgrading from non-TLS verification version. 
             * 
             * If they have not used Controller & Scanner mode before,
             * verification will remain enabled; otherwise, it will be disabled.
             */
-            if ((user != null && !user.isEmpty()) && (serverCertificate == null || serverCertificate.isEmpty())) {
+
+            if (isFromNonTLSVerificationVersion() && (user != null && !user.isEmpty()) && (serverCertificate == null || serverCertificate.isEmpty())) {
                 disableTLSCertVerification = true;
             }
 

--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorBuilder.java
@@ -588,14 +588,6 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
             load();
         }
 
-        private boolean isFromNonTLSVerificationVersion() {
-            /*
-             * ServerCertificate must be null if the plugin is new installed or migrated from non-TLS verification version,
-             * since we add serverCertificate when we have TLS verification.
-             */
-            return (serverCertificate == null);
-        }
-
         public ListBoxModel doFillRegistrySelectionItems() {
             ListBoxModel items = new ListBoxModel();
             items.add(REGISTRY_DROPDOWN_DEFAULT);
@@ -716,12 +708,17 @@ public class NeuVectorBuilder extends Builder implements SimpleBuildStep {
             * To ensure compatibility with users who are upgrading from non-TLS verification version, 
             * we check if the user has previously used API mode when upgrading from non-TLS verification version. 
             * 
+            * To check if this is a migrated from non-TLS verification version, we can check serverCertificate is null,
+            * since we add serverCertificate when we have TLS verification.
+            * 
             * If they have not used Controller & Scanner mode before,
             * verification will remain enabled; otherwise, it will be disabled.
             */
 
-            if (isFromNonTLSVerificationVersion() && (user != null && !user.isEmpty()) && (serverCertificate == null || serverCertificate.isEmpty())) {
-                disableTLSCertVerification = true;
+            boolean migrated = (serverCertificate == null);
+            
+            if (migrated) {
+                disableTLSCertVerification = (user != null && !user.isEmpty());
             }
 
             /*


### PR DESCRIPTION
### Summary
1. Add isFromNonTLSVerificationVersion flag, to check if the plugin upgrade from 1.x or newinstall

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
