### PR TITLE
NVSHAS-7792 Bugfix for jdk17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>neuvector-vulnerability-scanner-1.9.1</tag>
+        <tag>neuvector-vulnerability-scanner-2.1</tag>
     </scm>
     <build>
         <pluginManagement>

--- a/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
+++ b/src/main/java/io/jenkins/plugins/neuvector/NeuVectorWorker.java
@@ -563,20 +563,8 @@ public class NeuVectorWorker {
                 throw new AbortException(causeMessage);
             }
         }  catch (SSLHandshakeException e) {
-            String causeMessage;
-            Throwable cause = e.getCause();
-            if (cause != null && cause instanceof sun.security.validator.ValidatorException) {
-                sun.security.validator.ValidatorException validatorException = (sun.security.validator.ValidatorException) cause;
-                Throwable nestedCause = validatorException.getCause();
-                if (nestedCause != null && nestedCause instanceof sun.security.provider.certpath.SunCertPathBuilderException) {
-                    causeMessage = "Server certificate verification error: " + nestedCause.getMessage();
-                } else {
-                    causeMessage = e.getMessage();
-                }
-            } else {
-                causeMessage = e.getMessage();
-            }
-             
+            String causeMessage = e.getMessage();
+
             if (logger != null) {
                 logger.println(causeMessage);
             }


### PR DESCRIPTION
### Summary

- JDK 17 has no `sun.security.validator.ValidatorException` , we just replace the error with the whole error msg from SSLHandshakeException.

### How to verify
<!-- Comment:
Provide a clear description of how this change was tested.
-->

### Testing done
<!-- Comment:
Provide a clear description of what item was tested.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
